### PR TITLE
ci(dependabot): 設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+      timezone: "Asia/Tokyo"
+    ignore:
+      - dependency-name: "@angular*"
+      - dependency-name: "rxjs"
+      - dependency-name: "tslib"
+      - dependency-name: "zone.js"
+      - dependency-name: "@types/node"
+      - dependency-name: "typescript"
+    commit-message:
+      prefix: "chore(deps): "


### PR DESCRIPTION
- リファレンス
  - https://docs.github.com/ja/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
- テンプレートファイル
  - `Insights > Dependency graph > Dependabot > Create config file` で作成した内容をコピー
- 設定値
  - package-ecosystem
    - AngularなのでNode.jsのnpm
  - schedule
    - デイリーやウィークリーだと手間なのでマンスリー
    - タイムゾーンは東京
  - ignore
    - AngularやNode.jsのバージョンアップは任意のタイミングで実施
  - commit-message
    - よくある`chore(deps): `
