### PR TITLE
chore(@types/node): update @types/node@ v12.11.1 -> v14.14.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6479,9 +6479,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.27.tgz",
-      "integrity": "sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
     },
     "@types/parse-json": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/cli": "~13.3.10",
     "@angular/compiler-cli": "~13.3.12",
     "@types/jest": "^28.1.1",
-    "@types/node": "^12.11.1",
+    "@types/node": "^14.14.31",
     "@typescript-eslint/eslint-plugin": "5.3.0",
     "@typescript-eslint/parser": "5.3.0",
     "eslint": "^8.2.0",


### PR DESCRIPTION
# @types/nodeをv14系にアップデートする

1. ## Node.jsバージョン確認
    ```sh
    >node -v
    v14.20.0
    ```

1. ## @types/nodeアップデートバージョン確認
    ```sh
    >npm info @types/node
    
    @types/node@18.13.0 | MIT | deps: none | versions: 1482
    TypeScript definitions for Node.js
    https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
    
    dist
    .tarball: https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz      
    .shasum: 0400d1e6ce87e9d3032c19eb6c58205b0d3f7850
    .unpackedSize: 3.6 MB
    
    maintainers:
    - types <ts-npm-types@microsoft.com>
    
    dist-tags:
    latest: 18.13.0  ts2.3: 12.12.6   ts2.7: 12.12.6   ts3.1: 14.10.1   ts3.5: 15.6.1    ts3.9: 17.0.41   ts4.3: 18.13.0   ts4.7: 18.13.0
    ts2.0: 12.12.6   ts2.4: 12.12.6   ts2.8: 13.13.4   ts3.2: 14.14.9   ts3.6: 16.6.2    ts4.0: 18.7.14   ts4.4: 18.13.0   ts4.8: 18.13.0
    ts2.1: 12.12.6   ts2.5: 12.12.6   ts2.9: 14.0.1    ts3.3: 14.14.20  ts3.7: 16.11.7   ts4.1: 18.11.9   ts4.5: 18.13.0   ts4.9: 18.13.0
    ts2.2: 12.12.6   ts2.6: 12.12.6   ts3.0: 14.6.0    ts3.4: 14.14.31  ts3.8: 17.0.21   ts4.2: 18.13.0   ts4.6: 18.13.0   ts5.0: 18.13.0
    
    published a week ago by types <ts-npm-types@microsoft.com>
    ```

1. ## アップデートする
    ```sh
    >npm install @types/node@14.14.31
    npm WARN ajv-keywords@3.5.2 requires a peer of ajv@^6.9.1 but none is installed. You must install peer dependencies yourself.
    npm WARN rxjs-for-await@0.0.2 requires a peer of rxjs@^6.0.0 but none is installed. You must install peer dependencies yourself.
    npm WARN update-browserslist-db@1.0.10 requires a peer of browserslist@>= 4.21.0 but none is installed. You must install peer dependencies yourself.
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-android-arm64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-android-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-android-arm64@0.14.22: wanted {"os":"android","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-darwin-64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-darwin-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-darwin-64@0.14.22: wanted {"os":"darwin","arch":"x64"} (current: 
    {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-darwin-arm64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-darwin-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-darwin-arm64@0.14.22: wanted {"os":"darwin","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-freebsd-64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-freebsd-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-freebsd-64@0.14.22: wanted {"os":"freebsd","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-freebsd-arm64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-freebsd-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-freebsd-arm64@0.14.22: wanted {"os":"freebsd","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-32@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-32):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-32@0.14.22: wanted {"os":"linux","arch":"ia32"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-64@0.14.22: wanted {"os":"linux","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-arm@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-arm):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-arm@0.14.22: wanted {"os":"linux","arch":"arm"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-arm64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-arm64@0.14.22: wanted {"os":"linux","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-mips64le@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-mips64le):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-mips64le@0.14.22: wanted {"os":"linux","arch":"mips64el"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-ppc64le@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-ppc64le):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-ppc64le@0.14.22: wanted {"os":"linux","arch":"ppc64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-riscv64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-riscv64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-riscv64@0.14.22: wanted {"os":"linux","arch":"riscv64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-s390x@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-linux-s390x):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-s390x@0.14.22: wanted {"os":"linux","arch":"s390x"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-netbsd-64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-netbsd-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-netbsd-64@0.14.22: wanted {"os":"netbsd","arch":"x64"} (current: 
    {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-openbsd-64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-openbsd-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-openbsd-64@0.14.22: wanted {"os":"openbsd","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-sunos-64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-sunos-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-sunos-64@0.14.22: wanted {"os":"sunos","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-windows-32@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-windows-32):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-windows-32@0.14.22: wanted {"os":"win32","arch":"ia32"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-windows-arm64@0.14.22 (node_modules\@angular-devkit\build-angular\node_modules\esbuild-windows-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-windows-arm64@0.14.22: wanted {"os":"win32","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-android-64@0.14.44 (node_modules\esbuild-android-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-android-64@0.14.44: wanted {"os":"android","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-android-arm64@0.14.44 (node_modules\esbuild-android-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-android-arm64@0.14.44: wanted {"os":"android","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-darwin-64@0.14.44 (node_modules\esbuild-darwin-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-darwin-64@0.14.44: wanted {"os":"darwin","arch":"x64"} (current: 
    {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-darwin-arm64@0.14.44 (node_modules\esbuild-darwin-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-darwin-arm64@0.14.44: wanted {"os":"darwin","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-freebsd-64@0.14.44 (node_modules\esbuild-freebsd-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-freebsd-64@0.14.44: wanted {"os":"freebsd","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-freebsd-arm64@0.14.44 (node_modules\esbuild-freebsd-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-freebsd-arm64@0.14.44: wanted {"os":"freebsd","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-32@0.14.44 (node_modules\esbuild-linux-32):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-32@0.14.44: wanted {"os":"linux","arch":"ia32"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-64@0.14.44 (node_modules\esbuild-linux-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-64@0.14.44: wanted {"os":"linux","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-arm@0.14.44 (node_modules\esbuild-linux-arm):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-arm@0.14.44: wanted {"os":"linux","arch":"arm"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-arm64@0.14.44 (node_modules\esbuild-linux-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-arm64@0.14.44: wanted {"os":"linux","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-mips64le@0.14.44 (node_modules\esbuild-linux-mips64le):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-mips64le@0.14.44: wanted {"os":"linux","arch":"mips64el"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-ppc64le@0.14.44 (node_modules\esbuild-linux-ppc64le):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-ppc64le@0.14.44: wanted {"os":"linux","arch":"ppc64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-riscv64@0.14.44 (node_modules\esbuild-linux-riscv64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-riscv64@0.14.44: wanted {"os":"linux","arch":"riscv64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-s390x@0.14.44 (node_modules\esbuild-linux-s390x):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-s390x@0.14.44: wanted {"os":"linux","arch":"s390x"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-netbsd-64@0.14.44 (node_modules\esbuild-netbsd-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-netbsd-64@0.14.44: wanted {"os":"netbsd","arch":"x64"} (current: 
    {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-openbsd-64@0.14.44 (node_modules\esbuild-openbsd-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-openbsd-64@0.14.44: wanted {"os":"openbsd","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-sunos-64@0.14.44 (node_modules\esbuild-sunos-64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-sunos-64@0.14.44: wanted {"os":"sunos","arch":"x64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-windows-32@0.14.44 (node_modules\esbuild-windows-32):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-windows-32@0.14.44: wanted {"os":"win32","arch":"ia32"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: esbuild-windows-arm64@0.14.44 (node_modules\esbuild-windows-arm64):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-windows-arm64@0.14.44: wanted {"os":"win32","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.2 (node_modules\fsevents):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: nice-napi@1.0.2 (node_modules\nice-napi):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for nice-napi@1.0.2: wanted {"os":"!win32","arch":"any"} (current: {"os":"win32","arch":"x64"})
    
    + @types/node@14.14.31
    updated 1 package and audited 1838 packages in 31.349s
    
    164 packages are looking for funding
      run `npm fund` for details
    
    found 36 vulnerabilities (24 high, 12 critical)
      run `npm audit fix` to fix them, or `npm audit` for details
    ```
