### PR TITLE
chore(jest): update jest-preset-angular v13.0.1 -> v13.1.0

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 globalThis.ngJest = {
-  skipNgcc: false,
   tsconfig: 'tsconfig.spec.json',
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@typescript-eslint/parser": "^5.43.0",
         "eslint": "^8.28.0",
         "jest": "^29.5.0",
-        "jest-preset-angular": "^13.0.1",
+        "jest-preset-angular": "^13.1.0",
         "stylelint": "^15.2.0",
         "stylelint-config-standard-scss": "^7.0.1",
         "typescript": "~4.9.5"
@@ -14987,9 +14987,9 @@
       }
     },
     "node_modules/jest-preset-angular": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-13.0.1.tgz",
-      "integrity": "sha512-kghzQHkD60oXXDoBM1lzbamleDMehTZKVLg2/BKXXRMuY0Or8iMvW0vUUzkdvax5ltssjPdnHUvuz8/KOnGjUg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-13.1.0.tgz",
+      "integrity": "sha512-qdADzclUA28JekmyZ48Y/StLJRb9VS76S7QjrtXJPBC3WCodEWYwclS0X5ZXJn3MlSNsrDDCBiNDoQjU0yNF6A==",
       "dev": true,
       "dependencies": {
         "bs-logger": "^0.2.6",
@@ -15006,10 +15006,10 @@
         "esbuild": ">=0.13.8"
       },
       "peerDependencies": {
-        "@angular-devkit/build-angular": ">=13.0.0 <16.0.0",
-        "@angular/compiler-cli": ">=13.0.0 <16.0.0",
-        "@angular/core": ">=13.0.0 <16.0.0",
-        "@angular/platform-browser-dynamic": ">=13.0.0 <16.0.0",
+        "@angular-devkit/build-angular": ">=13.0.0 <17.0.0",
+        "@angular/compiler-cli": ">=13.0.0 <17.0.0",
+        "@angular/core": ">=13.0.0 <17.0.0",
+        "@angular/platform-browser-dynamic": ">=13.0.0 <17.0.0",
         "jest": "^29.0.0",
         "typescript": ">=4.4"
       }
@@ -32884,9 +32884,9 @@
       "requires": {}
     },
     "jest-preset-angular": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-13.0.1.tgz",
-      "integrity": "sha512-kghzQHkD60oXXDoBM1lzbamleDMehTZKVLg2/BKXXRMuY0Or8iMvW0vUUzkdvax5ltssjPdnHUvuz8/KOnGjUg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-13.1.0.tgz",
+      "integrity": "sha512-qdADzclUA28JekmyZ48Y/StLJRb9VS76S7QjrtXJPBC3WCodEWYwclS0X5ZXJn3MlSNsrDDCBiNDoQjU0yNF6A==",
       "dev": true,
       "requires": {
         "bs-logger": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/parser": "^5.43.0",
     "eslint": "^8.28.0",
     "jest": "^29.5.0",
-    "jest-preset-angular": "^13.0.1",
+    "jest-preset-angular": "^13.1.0",
     "stylelint": "^15.2.0",
     "stylelint-config-standard-scss": "^7.0.1",
     "typescript": "~4.9.5"


### PR DESCRIPTION
# jest-preset-angularをv13系にアップデートする

1. ## 現行バージョン確認
    ```sh
    >npm outdated
    Package                                 Current   Wanted   Latest  Location                                             Depended by
    ~省略~
    @types/jest                              29.5.2  29.5.12  29.5.12  node_modules/@types/jest                             angular
    ~省略~
    jest                                     29.5.0   29.7.0   29.7.0  node_modules/jest                                    angular
    jest-preset-angular                      13.0.1   13.1.6   14.0.3  node_modules/jest-preset-angular                     angular
    ~省略~
    ```

1. ## アップデートする
    ```sh
    >npm install jest-preset-angular@13.1.0   

    removed 1 package, changed 1 package, and audited 1701 packages in 28s
    
    178 packages are looking for funding
      run `npm fund` for details
    
    15 vulnerabilities (9 moderate, 4 high, 2 critical)
    
    To address all issues, run:
      npm audit fix
    
    Run `npm audit` for details.
    ```

1. ## アップデートバージョン確認
    ```sh
    >npm outdated
    Package                                 Current   Wanted   Latest  Location                                             Depended by
    ~省略~
    @types/jest                              29.5.2  29.5.12  29.5.12  node_modules/@types/jest                             angular
    ~省略~
    jest                                     29.5.0   29.7.0   29.7.0  node_modules/jest                                    angular
    jest-preset-angular                      13.1.0   13.1.6   14.0.3  node_modules/jest-preset-angular                     angular
    ~省略~
    ```